### PR TITLE
flake: Add shellHook to mkDerivation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
                 };
                 config.nix-bindings-rust = {
                   nciBuildConfig = {
-                    mkDerivation = {
+                    mkDerivation = rec {
                       buildInputs = [
                         # stdbool.h
                         pkgs.stdenv.cc
@@ -88,6 +88,7 @@
                       postConfigure = lib.optionalString pkgs.stdenv.cc.isGNU ''
                         source ${./bindgen-gcc.sh}
                       '';
+                      shellHook = postConfigure;
                     };
                     # NOTE: duplicated in flake.nix devShell
                     env = {


### PR DESCRIPTION
Otherwise, we don't run the bindgen script while entering a devShell.