### PR TITLE
nix-bindings-expr: implement Send for EvalState and Value

### DIFF
--- a/nix-bindings-expr/src/eval_state.rs
+++ b/nix-bindings-expr/src/eval_state.rs
@@ -1200,6 +1200,8 @@ impl Clone for EvalState {
     }
 }
 
+unsafe impl Send for EvalState { }
+
 /// Initialize the Nix library for testing. This includes some modifications to the Nix settings, that must not be used in production.
 /// Use at your own peril, in rust test suites.
 #[doc(alias = "test_initialize")]

--- a/nix-bindings-expr/src/value.rs
+++ b/nix-bindings-expr/src/value.rs
@@ -123,4 +123,6 @@ impl Clone for Value {
     }
 }
 
+unsafe impl Send for Value { }
+
 // Tested in eval_state.rs


### PR DESCRIPTION
As discussed in #11. Not sure if these are actually safe, would be good to verify before merging. But I have not seen problems.