### PR TITLE
fix(nix-bindings-rust): fix aarch64 abi support

### DIFF
--- a/nix-bindings-util/src/context.rs
+++ b/nix-bindings-util/src/context.rs
@@ -144,7 +144,7 @@ mod tests {
             raw::set_err_msg(
                 ctx_ptr,
                 raw::err_NIX_ERR_UNKNOWN.try_into().unwrap(),
-                b"dummy error message\0".as_ptr() as *const i8,
+                b"dummy error message\0".as_ptr() as *const std::os::raw::c_char,
             );
         }
     }

--- a/nix-bindings-util/src/string_return.rs
+++ b/nix-bindings-util/src/string_return.rs
@@ -75,7 +75,7 @@ mod tests {
     #[test]
     fn test_callback_result_string() {
         let mut ret: Result<String> = result_string_init!();
-        let start: *const std::os::raw::c_char = b"helloGARBAGE".as_ptr() as *const i8;
+        let start = b"helloGARBAGE".as_ptr() as *const std::os::raw::c_char;
         let n: std::os::raw::c_uint = 5;
         let user_data: *mut std::os::raw::c_void = callback_get_result_string_data(&mut ret);
         unsafe {


### PR DESCRIPTION
Similar to https://github.com/nixops4/nixops4/pull/118, same motivation and same errors.