### PR TITLE
store: add Store method wrappers for hydra

### DIFF
--- a/nix-bindings-store/src/path/mod.rs
+++ b/nix-bindings-store/src/path/mod.rs
@@ -62,7 +62,7 @@ impl StorePath {
             check_call!(raw::store_create_from_parts(
                 &mut ctx,
                 hash_part,
-                name.as_ptr() as *const i8,
+                name.as_ptr() as *const std::ffi::c_char,
                 name.len()
             ))?
         };

--- a/nix-bindings-store/src/store.rs
+++ b/nix-bindings-store/src/store.rs
@@ -410,6 +410,35 @@ impl Store {
         Ok(r)
     }
 
+    /// Check whether a store path is valid (exists in the store).
+    #[doc(alias = "nix_store_is_valid_path")]
+    pub fn is_valid_path(&mut self, path: &StorePath) -> bool {
+        // is_valid_path returns bool directly, not nix_err
+        unsafe { raw::store_is_valid_path(self.context.ptr(), self.inner.ptr(), path.as_ptr()) }
+    }
+
+    /// Copy a single store path from one store to another.
+    #[doc(alias = "nix_store_copy_path")]
+    pub fn copy_path(
+        &mut self,
+        dst_store: &mut Store,
+        path: &StorePath,
+        repair: bool,
+        check_sigs: bool,
+    ) -> Result<()> {
+        unsafe {
+            check_call!(raw::store_copy_path(
+                &mut self.context,
+                self.inner.ptr(),
+                dst_store.inner.ptr(),
+                path.as_ptr(),
+                repair,
+                check_sigs
+            ))?;
+        }
+        Ok(())
+    }
+
     pub fn weak_ref(&self) -> StoreWeak {
         StoreWeak {
             inner: Arc::downgrade(&self.inner),

--- a/nix-bindings-store/src/store.rs
+++ b/nix-bindings-store/src/store.rs
@@ -439,6 +439,69 @@ impl Store {
         Ok(())
     }
 
+    /// Copy a store path and its entire closure from one store to another.
+    #[doc(alias = "nix_store_copy_closure")]
+    pub fn copy_closure(&mut self, dst_store: &mut Store, path: &StorePath) -> Result<()> {
+        unsafe {
+            check_call!(raw::store_copy_closure(
+                &mut self.context,
+                self.inner.ptr(),
+                dst_store.inner.ptr(),
+                path.as_ptr() as *mut raw::StorePath // C API takes non-const StorePath*
+            ))?;
+        }
+        Ok(())
+    }
+
+    /// Query a store path by its hash part.
+    ///
+    /// Returns `None` if no path with that hash exists.
+    #[doc(alias = "nix_store_query_path_from_hash_part")]
+    pub fn query_path_from_hash_part(&mut self, hash: &str) -> Result<Option<StorePath>> {
+        let hash = std::ffi::CString::new(hash)?;
+        let ptr = unsafe {
+            raw::store_query_path_from_hash_part(
+                self.context.ptr(),
+                self.inner.ptr(),
+                hash.as_ptr(),
+            )
+        };
+        Ok(NonNull::new(ptr).map(|p| unsafe { StorePath::new_raw(p) }))
+    }
+
+    /// Read a derivation from the store by its store path.
+    ///
+    /// **Requires Nix 2.33 or later.**
+    #[cfg(nix_at_least = "2.33.0pre")]
+    #[doc(alias = "nix_store_drv_from_store_path")]
+    pub fn derivation_from_path(&mut self, path: &StorePath) -> Result<Derivation> {
+        unsafe {
+            let drv = check_call!(raw::store_drv_from_store_path(
+                &mut self.context,
+                self.inner.ptr(),
+                path.as_ptr()
+            ))?;
+            let inner =
+                NonNull::new(drv).ok_or_else(|| Error::msg("drv_from_store_path returned null"))?;
+            Ok(Derivation::new_raw(inner))
+        }
+    }
+
+    /// Get the Nix version string of the store daemon.
+    #[doc(alias = "nix_store_get_version")]
+    pub fn get_version(&mut self) -> Result<String> {
+        let mut r = result_string_init!();
+        unsafe {
+            check_call!(raw::store_get_version(
+                &mut self.context,
+                self.inner.ptr(),
+                Some(callback_get_result_string),
+                callback_get_result_string_data(&mut r)
+            ))
+        }?;
+        r
+    }
+
     pub fn weak_ref(&self) -> StoreWeak {
         StoreWeak {
             inner: Arc::downgrade(&self.inner),


### PR DESCRIPTION
## Summary

This PR wraps several Nix C API store functions for future use in hydra's queue-runner.

- `is_valid_path`: checks if a store path exists
- `copy_path` / `copy_closure`: copy a single path or a full closure between stores
- `query_path_from_hash_part`: look up a store path by its hash prefix
- `get_version`: get the store protocol version string
- `derivation_from_path` : parse a .drv file into its components