### PR TITLE
Refactor `EvalState` to not use `Arc`s, label `Store`'s significant drops

### DIFF
--- a/nix-bindings-expr/src/eval_state.rs
+++ b/nix-bindings-expr/src/eval_state.rs
@@ -136,7 +136,7 @@ use cstr::cstr;
 use nix_bindings_bdwgc_sys as gc;
 use nix_bindings_expr_sys as raw;
 use nix_bindings_store::path::StorePath;
-use nix_bindings_store::store::{Store, StoreWeak};
+use nix_bindings_store::store::Store;
 use nix_bindings_store_sys as raw_store;
 use nix_bindings_util::context::Context;
 use nix_bindings_util::string_return::{
@@ -147,7 +147,7 @@ use std::ffi::{c_char, CString};
 use std::iter::FromIterator;
 use std::os::raw::c_uint;
 use std::ptr::{null, null_mut, NonNull};
-use std::sync::{Arc, LazyLock, Weak};
+use std::sync::LazyLock;
 
 static INIT: LazyLock<Result<()>> = LazyLock::new(|| unsafe {
     gc::GC_allow_register_threads();
@@ -176,26 +176,7 @@ pub struct RealisedString {
     pub paths: Vec<StorePath>,
 }
 
-/// A [Weak] reference to an [EvalState].
-pub struct EvalStateWeak {
-    inner: Weak<EvalStateRef>,
-    store: StoreWeak,
-}
-impl EvalStateWeak {
-    /// Upgrade the weak reference to a proper [EvalState].
-    ///
-    /// If no normal reference to the [EvalState] is around anymore elsewhere, this fails by returning `None`.
-    pub fn upgrade(&self) -> Option<EvalState> {
-        self.inner.upgrade().and_then(|eval_state| {
-            self.store.upgrade().map(|store| EvalState {
-                eval_state,
-                store,
-                context: Context::new(),
-            })
-        })
-    }
-}
-
+#[clippy::has_significant_drop]
 struct EvalStateRef {
     eval_state: NonNull<raw::EvalState>,
 }
@@ -331,11 +312,11 @@ impl EvalStateBuilder {
         let eval_state =
             unsafe { check_call!(raw::eval_state_build(&mut context, self.eval_state_builder)) }?;
         Ok(EvalState {
-            eval_state: Arc::new(EvalStateRef {
+            eval_state: EvalStateRef {
                 eval_state: NonNull::new(eval_state).unwrap_or_else(|| {
                     panic!("nix_state_create returned a null pointer without an error")
                 }),
-            }),
+            },
             store: self.store.clone(),
             context,
         })
@@ -351,8 +332,13 @@ impl EvalStateBuilder {
     }
 }
 
+/// An abstraction over the underlying eval state.
+///
+/// When an `EvalState` is constructed, it will allocate a number of threads to be used for
+/// evaluating expressions. These threads will remain allocated until the `EvalState` is dropped.
+#[clippy::has_significant_drop]
 pub struct EvalState {
-    eval_state: Arc<EvalStateRef>,
+    eval_state: EvalStateRef,
     store: Store,
     pub(crate) context: Context,
 }
@@ -378,14 +364,6 @@ impl EvalState {
     /// Returns a reference to the Store that's used for instantiation, import from derivation, etc.
     pub fn store(&self) -> &Store {
         &self.store
-    }
-
-    /// Creates a weak reference to this EvalState.
-    pub fn weak_ref(&self) -> EvalStateWeak {
-        EvalStateWeak {
-            inner: Arc::downgrade(&self.eval_state),
-            store: self.store.weak_ref(),
-        }
     }
 
     /// Parses and evaluates a Nix expression `expr`.
@@ -842,7 +820,7 @@ impl EvalState {
             Box::new(move |eval_state, _dummy: &[Value; 1]| f(eval_state)),
         )?;
 
-        let p = self.new_value_primop(primop)?;
+        let p = primop.new_value()?;
         self.new_value_apply(&p, &p)
     }
 
@@ -1035,7 +1013,7 @@ impl EvalState {
         Ok(value)
     }
 
-    fn new_value_uninitialized(&mut self) -> Result<Value> {
+    pub(crate) fn new_value_uninitialized(&mut self) -> Result<Value> {
         unsafe {
             let value = check_call!(raw::alloc_value(
                 &mut self.context,
@@ -1050,19 +1028,17 @@ impl EvalState {
     /// This is also known as a "primop" in Nix, short for primitive operation.
     /// Most of the `builtins.*` values are examples of primops, but this function
     /// does not affect `builtins`.
+    ///
+    /// # Deprecated
+    ///
+    /// This function is deprecated and has been replaced by
+    /// [`PrimOp::new_value`](crate::primop::PrimOp::new_value).
     #[doc(alias = "make_primop")]
     #[doc(alias = "create_function")]
     #[doc(alias = "builtin")]
-    pub fn new_value_primop(&mut self, primop: primop::PrimOp) -> Result<Value> {
-        let value = self.new_value_uninitialized()?;
-        unsafe {
-            check_call!(raw::init_primop(
-                &mut self.context,
-                value.raw_ptr(),
-                primop.ptr
-            ))?;
-        };
-        Ok(value)
+    #[deprecated = "use `PrimOp::new_value` instead"]
+    pub fn new_value_primop(primop: primop::PrimOp) -> Result<Value> {
+        primop.new_value()
     }
 
     /// Creates a new [attribute set][`ValueType::AttrSet`] Nix value from an iterator of name-value pairs.
@@ -1220,16 +1196,6 @@ pub fn gc_register_my_thread() -> Result<ThreadRegistrationGuard> {
     }
 }
 
-impl Clone for EvalState {
-    fn clone(&self) -> Self {
-        EvalState {
-            eval_state: self.eval_state.clone(),
-            store: self.store.clone(),
-            context: Context::new(),
-        }
-    }
-}
-
 /// Initialize the Nix library for testing. This includes some modifications to the Nix settings, that must not be used in production.
 /// Use at your own peril, in rust test suites.
 #[doc(alias = "test_initialize")]
@@ -1294,33 +1260,6 @@ mod tests {
             // very basic test: make sure initialization doesn't crash
             let store = Store::open(None, HashMap::new()).unwrap();
             let _e = EvalState::new(store, []).unwrap();
-        })
-        .unwrap();
-    }
-
-    #[test]
-    fn weak_ref() {
-        gc_registering_current_thread(|| {
-            let store = Store::open(None, HashMap::new()).unwrap();
-            let es = EvalState::new(store, []).unwrap();
-            let weak = es.weak_ref();
-            let _es = weak.upgrade().unwrap();
-        })
-        .unwrap();
-    }
-
-    #[test]
-    fn weak_ref_gone() {
-        gc_registering_current_thread(|| {
-            let weak = {
-                // Use a slightly different URL which is unique in the test suite, to bypass the global store cache
-                let store = Store::open(Some("auto?foo=bar"), HashMap::new()).unwrap();
-                let es = EvalState::new(store, []).unwrap();
-                es.weak_ref()
-            };
-            assert!(weak.upgrade().is_none());
-            assert!(weak.store.upgrade().is_none());
-            assert!(weak.inner.upgrade().is_none());
         })
         .unwrap();
     }
@@ -2252,7 +2191,7 @@ mod tests {
             )
             .unwrap();
 
-            let f = es.new_value_primop(primop).unwrap();
+            let f = primop.new_value().unwrap();
 
             {
                 *bias_control.lock().unwrap() = 10;
@@ -2291,7 +2230,7 @@ mod tests {
                 )
                 .unwrap();
 
-                es.new_value_primop(prim)
+                prim.new_value()
             }
             .unwrap();
             let a = es.new_value_int(2).unwrap();
@@ -2382,7 +2321,7 @@ mod tests {
                 }),
             )
             .unwrap();
-            let f = es.new_value_primop(primop).unwrap();
+            let f = primop.new_value().unwrap();
             let a = es.new_value_int(2).unwrap();
             let b = es.new_value_int(3).unwrap();
             let fa = es.call(f, a).unwrap();
@@ -2411,7 +2350,7 @@ mod tests {
                 Box::new(|_es, _args| bail!("The frob unexpectedly fizzled")),
             )
             .unwrap();
-            let f = es.new_value_primop(primop).unwrap();
+            let f = primop.new_value().unwrap();
             let a = es.new_value_int(0).unwrap();
             match es.call(f, a) {
                 Ok(_) => panic!("expected an error"),

--- a/nix-bindings-expr/src/primop.rs
+++ b/nix-bindings-expr/src/primop.rs
@@ -1,4 +1,4 @@
-use crate::eval_state::{EvalState, EvalStateWeak};
+use crate::eval_state::EvalState;
 use crate::value::Value;
 use anyhow::Result;
 use nix_bindings_expr_sys as raw;
@@ -54,27 +54,28 @@ pub struct PrimOpMeta<'a, const N: usize> {
     pub args: [&'a CStr; N],
 }
 
-pub struct PrimOp {
-    pub(crate) ptr: *mut raw::PrimOp,
+pub struct PrimOp<'a> {
+    ptr: *mut raw::PrimOp,
+    eval_state: &'a mut EvalState,
 }
-impl Drop for PrimOp {
+impl Drop for PrimOp<'_> {
     fn drop(&mut self) {
         unsafe {
             raw::gc_decref(null_mut(), self.ptr as *mut c_void);
         }
     }
 }
-impl PrimOp {
+impl<'a> PrimOp<'a> {
     /// Create a new primop with the given metadata and implementation.
     ///
     /// When `f` returns an `Err`, the error is propagated to the Nix evaluator.
     /// To return a [recoverable error](RecoverableError), include it in the
     /// error chain (e.g. `Err(RecoverableError::new("...").into())`).
     pub fn new<const N: usize>(
-        eval_state: &mut EvalState,
+        eval_state: &'a mut EvalState,
         meta: PrimOpMeta<N>,
         f: Box<dyn Fn(&mut EvalState, &[Value; N]) -> Result<Value>>,
-    ) -> Result<PrimOp> {
+    ) -> Result<PrimOp<'a>> {
         assert!(N != 0);
 
         let mut args = Vec::new();
@@ -91,7 +92,7 @@ impl PrimOp {
             let user_data = ManuallyDrop::new(Box::new(PrimOpContext {
                 arity: N,
                 function: Box::new(move |eval_state, args| f(eval_state, args.try_into().unwrap())),
-                eval_state: eval_state.weak_ref(),
+                eval_state,
             }));
             user_data.as_ref() as *const PrimOpContext as *mut c_void
         };
@@ -106,15 +107,44 @@ impl PrimOp {
                 user_data
             ))?
         };
-        Ok(PrimOp { ptr: op })
+
+        Ok(PrimOp {
+            ptr: op,
+            eval_state,
+        })
+    }
+
+    /// Creates a new [`function`](crate::value::ValueType::Function) Nix value implemented by a Rust function.
+    ///
+    /// This is also known as a "primop" in Nix, short for primitive operation.
+    /// Most of the `builtins.*` values are examples of primops, but this function
+    /// does not affect `builtins`.
+    #[doc(alias = "make_primop")]
+    #[doc(alias = "create_function")]
+    #[doc(alias = "builtin")]
+    pub fn new_value(mut self) -> Result<Value> {
+        self.with_state_and_ptr(|ptr, this| {
+            let value = this.new_value_uninitialized()?;
+            unsafe {
+                check_call!(raw::init_primop(&mut this.context, value.raw_ptr(), ptr))?;
+            };
+            Ok(value)
+        })
+    }
+
+    pub(crate) fn with_state_and_ptr<F, T>(&mut self, f: F) -> T
+    where
+        F: Fn(*mut raw::PrimOp, &mut EvalState) -> T,
+    {
+        f(self.ptr, self.eval_state)
     }
 }
 
 /// The user_data for our Nix primops
-struct PrimOpContext {
+struct PrimOpContext<'a> {
     arity: usize,
     function: Box<dyn Fn(&mut EvalState, &[Value]) -> Result<Value>>,
-    eval_state: EvalStateWeak,
+    eval_state: &'a mut EvalState,
 }
 
 unsafe extern "C" fn function_adapter(
@@ -124,10 +154,7 @@ unsafe extern "C" fn function_adapter(
     args: *mut *mut raw::Value,
     ret: *mut raw::Value,
 ) {
-    let primop_info = (user_data as *const PrimOpContext).as_ref().unwrap();
-    let mut eval_state = primop_info.eval_state.upgrade().unwrap_or_else(|| {
-        panic!("Nix primop called after EvalState was dropped");
-    });
+    let primop_info = (user_data as *mut PrimOpContext).as_mut().unwrap();
     let args_raw_slice = unsafe { std::slice::from_raw_parts(args, primop_info.arity) };
     let args_vec: Vec<Value> = args_raw_slice
         .iter()
@@ -135,7 +162,7 @@ unsafe extern "C" fn function_adapter(
         .collect();
     let args_slice = args_vec.as_slice();
 
-    let r = primop_info.function.as_ref()(&mut eval_state, args_slice);
+    let r = primop_info.function.as_ref()(primop_info.eval_state, args_slice);
 
     match r {
         Ok(v) => unsafe {

--- a/nix-bindings-expr/src/primop.rs
+++ b/nix-bindings-expr/src/primop.rs
@@ -5,7 +5,6 @@ use nix_bindings_expr_sys as raw;
 use nix_bindings_util::check_call;
 use nix_bindings_util_sys as raw_util;
 use std::ffi::{c_int, c_void, CStr, CString};
-use std::mem::ManuallyDrop;
 use std::ptr::{null, null_mut};
 
 /// A primop error that is not memoized in the thunk that triggered it,
@@ -89,12 +88,12 @@ impl<'a> PrimOp<'a> {
         let user_data = {
             // We'll be leaking this Box.
             // TODO: Use the GC with finalizer, if possible.
-            let user_data = ManuallyDrop::new(Box::new(PrimOpContext {
+            let user_data = Box::leak(Box::new(PrimOpContext {
                 arity: N,
                 function: Box::new(move |eval_state, args| f(eval_state, args.try_into().unwrap())),
                 eval_state,
             }));
-            user_data.as_ref() as *const PrimOpContext as *mut c_void
+            user_data as *const PrimOpContext as *mut c_void
         };
         let op = unsafe {
             check_call!(raw::alloc_primop(

--- a/nix-bindings-store/src/store.rs
+++ b/nix-bindings-store/src/store.rs
@@ -24,6 +24,7 @@ static INIT: LazyLock<Result<()>> = LazyLock::new(|| unsafe {
     Ok(())
 });
 
+#[clippy::has_significant_drop]
 struct StoreRef {
     inner: NonNull<raw::Store>,
 }


### PR DESCRIPTION
This PR refactors the `EvalState` to no longer use an internal `Arc` and remove its `Clone` implementation. The reason for this is that an `EvalState` allocates several resources over its lifetime that are held until it is `Drop`ped.

Downstream crates can still wrap it in `Rc` if they need `Clone`, or `Arc<Mutex<>>` if they also need `Send + Sync`. This also has the advantage of maintaining a single `Context` across clones.

This also inadvertently fixes a potential issue with `PrimOp` where we used to access `EvalState` via a mutable reference constructed from a raw pointer (while potentially still holding references elsewhere), which is now protected against by the borrow checker. 

As for the `Store`, the inner `Arc` is maintained (for now), due to the need to work around https://github.com/NixOS/nix/issues/11979 - but the `Drop` significance is now clearly labeled & documented.

---

Upstream of https://github.com/DeterminateSystems/nix-bindings-rust/pull/15