### PR TITLE
Primop registration, i.e. `builtins`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- `EvalState::store()`. Consumers need to track the `Store` themselves.
+
 ## [0.2.1] - 2026-05-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - `EvalState::store()`. Consumers need to track the `Store` themselves.
+- `impl Clone for EvalState`: since a C API `EvalState` can be a borrowed one,
+   and it doesn't provide a clone function, we can't provide a safe clone operation.
+- `EvalStateWeak`: the internal `Arc` was removed; sharing is now a consumer responsibility.
+  This is more efficient and flexible, and truthful to the C API.
+- `impl Send/Sync for EvalState` the C API doesn't make these promises, so neither should
+  `nix-bindings-rust`. Thread safety is improving upstream, but if you want to take this risk,
+  it should be an intentional opt-in.
 
 ## [0.2.1] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `PrimOp::register_globally` — register a primop as a global builtin via `nix_register_primop`, making it callable from every `EvalState` created afterwards.
+  Nix does not support `EvalState`-scoped extensions to `builtins` as of writing.
+  This addition required some breaking changes and triggered some cleanups.
+
+### Changed
+
+- **Breaking**: `PrimOp::new` no longer takes `&mut EvalState`
+- Deprecation: `EvalState::new_value_primop` -> `PrimOp::into_value`
+  Primops are now constructed independent of any evaluation state, so that built-ins
+  can be registered ahead of `EvalState` construction, and be run in any `EvalState`
+  context.
+  Migration for ad hoc primop creation call sites:
+  ```rust
+  // before
+  let prim = PrimOp::new(&mut es, meta, Box::new(|es, args| ...))?;
+  let f   = es.new_value_primop(prim)?;
+  // after
+  let prim = PrimOp::new(meta, Box::new(|es, args| ...))?;
+  let f   = prim.into_value(&mut es)?;
+  ```
+
 ### Removed
 
 - `EvalState::store()`. Consumers need to track the `Store` themselves.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,7 @@ dependencies = [
  "nix-bindings-util",
  "nix-bindings-util-sys",
  "pkg-config",
+ "static_assertions",
  "tempfile",
 ]
 
@@ -1031,6 +1032,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/nix-bindings-expr/Cargo.toml
+++ b/nix-bindings-expr/Cargo.toml
@@ -28,6 +28,9 @@ cstr = "0.2"
 pkg-config = "0.3"
 nix-bindings-util = { path = "../nix-bindings-util", version = "0.2.2" }
 
+[dev-dependencies]
+static_assertions = "1.1"
+
 [lints.rust]
 warnings = "deny"
 dead-code = "allow"

--- a/nix-bindings-expr/src/eval_state.rs
+++ b/nix-bindings-expr/src/eval_state.rs
@@ -192,8 +192,10 @@ impl EvalStateWeak {
     }
 }
 
-struct EvalStateRef {
+pub(crate) struct EvalStateRef {
     eval_state: NonNull<raw::EvalState>,
+    /// Only `nix_state_free` on `drop` when `true`.
+    owned: bool,
 }
 impl EvalStateRef {
     /// Returns a raw pointer to the underlying EvalState.
@@ -207,8 +209,10 @@ impl EvalStateRef {
 }
 impl Drop for EvalStateRef {
     fn drop(&mut self) {
-        unsafe {
-            raw::state_free(self.eval_state.as_ptr());
+        if self.owned {
+            unsafe {
+                raw::state_free(self.eval_state.as_ptr());
+            }
         }
     }
 }
@@ -331,6 +335,7 @@ impl EvalStateBuilder {
                 eval_state: NonNull::new(eval_state).unwrap_or_else(|| {
                     panic!("nix_state_create returned a null pointer without an error")
                 }),
+                owned: true,
             }),
             context,
         })
@@ -373,6 +378,21 @@ impl EvalState {
     pub fn weak_ref(&self) -> EvalStateWeak {
         EvalStateWeak {
             inner: Arc::downgrade(&self.eval_state),
+        }
+    }
+
+    /// Wraps a raw `EvalState *` borrowed from the Nix C API.
+    ///
+    /// # Safety
+    ///
+    /// The returned `EvalState` must not outlive the underlying pointer.
+    pub(crate) unsafe fn from_raw_borrowed(ptr: NonNull<raw::EvalState>) -> Self {
+        EvalState {
+            eval_state: Arc::new(EvalStateRef {
+                eval_state: ptr,
+                owned: false,
+            }),
+            context: Context::new(),
         }
     }
 

--- a/nix-bindings-expr/src/eval_state.rs
+++ b/nix-bindings-expr/src/eval_state.rs
@@ -136,7 +136,7 @@ use cstr::cstr;
 use nix_bindings_bdwgc_sys as gc;
 use nix_bindings_expr_sys as raw;
 use nix_bindings_store::path::StorePath;
-use nix_bindings_store::store::{Store, StoreWeak};
+use nix_bindings_store::store::Store;
 use nix_bindings_store_sys as raw_store;
 use nix_bindings_util::context::Context;
 use nix_bindings_util::string_return::{
@@ -179,19 +179,15 @@ pub struct RealisedString {
 /// A [Weak] reference to an [EvalState].
 pub struct EvalStateWeak {
     inner: Weak<EvalStateRef>,
-    store: StoreWeak,
 }
 impl EvalStateWeak {
     /// Upgrade the weak reference to a proper [EvalState].
     ///
     /// If no normal reference to the [EvalState] is around anymore elsewhere, this fails by returning `None`.
     pub fn upgrade(&self) -> Option<EvalState> {
-        self.inner.upgrade().and_then(|eval_state| {
-            self.store.upgrade().map(|store| EvalState {
-                eval_state,
-                store,
-                context: Context::new(),
-            })
+        self.inner.upgrade().map(|eval_state| EvalState {
+            eval_state,
+            context: Context::new(),
         })
     }
 }
@@ -336,7 +332,6 @@ impl EvalStateBuilder {
                     panic!("nix_state_create returned a null pointer without an error")
                 }),
             }),
-            store: self.store.clone(),
             context,
         })
     }
@@ -353,7 +348,6 @@ impl EvalStateBuilder {
 
 pub struct EvalState {
     eval_state: Arc<EvalStateRef>,
-    store: Store,
     pub(crate) context: Context,
 }
 impl EvalState {
@@ -375,16 +369,10 @@ impl EvalState {
         self.eval_state.as_ptr()
     }
 
-    /// Returns a reference to the Store that's used for instantiation, import from derivation, etc.
-    pub fn store(&self) -> &Store {
-        &self.store
-    }
-
     /// Creates a weak reference to this EvalState.
     pub fn weak_ref(&self) -> EvalStateWeak {
         EvalStateWeak {
             inner: Arc::downgrade(&self.eval_state),
-            store: self.store.weak_ref(),
         }
     }
 
@@ -1224,7 +1212,6 @@ impl Clone for EvalState {
     fn clone(&self) -> Self {
         EvalState {
             eval_state: self.eval_state.clone(),
-            store: self.store.clone(),
             context: Context::new(),
         }
     }
@@ -1319,7 +1306,6 @@ mod tests {
                 es.weak_ref()
             };
             assert!(weak.upgrade().is_none());
-            assert!(weak.store.upgrade().is_none());
             assert!(weak.inner.upgrade().is_none());
         })
         .unwrap();

--- a/nix-bindings-expr/src/eval_state.rs
+++ b/nix-bindings-expr/src/eval_state.rs
@@ -815,7 +815,6 @@ impl EvalState {
         // create a function and pass it a dummy argument.
         let name = CString::new(name).with_context(|| "new_thunk: name contains null byte")?;
         let primop = primop::PrimOp::new(
-            self,
             primop::PrimOpMeta {
                 // name is observable in stack traces, ie if the thunk returns Err
                 name: name.as_c_str(),
@@ -827,7 +826,7 @@ impl EvalState {
             Box::new(move |eval_state, _dummy: &[Value; 1]| f(eval_state)),
         )?;
 
-        let p = self.new_value_primop(primop)?;
+        let p = primop.into_value(self)?;
         self.new_value_apply(&p, &p)
     }
 
@@ -1020,7 +1019,7 @@ impl EvalState {
         Ok(value)
     }
 
-    fn new_value_uninitialized(&mut self) -> Result<Value> {
+    pub(crate) fn new_value_uninitialized(&mut self) -> Result<Value> {
         unsafe {
             let value = check_call!(raw::alloc_value(
                 &mut self.context,
@@ -1030,24 +1029,9 @@ impl EvalState {
         }
     }
 
-    /// Creates a new [function][`ValueType::Function`] Nix value implemented by a Rust function.
-    ///
-    /// This is also known as a "primop" in Nix, short for primitive operation.
-    /// Most of the `builtins.*` values are examples of primops, but this function
-    /// does not affect `builtins`.
-    #[doc(alias = "make_primop")]
-    #[doc(alias = "create_function")]
-    #[doc(alias = "builtin")]
+    #[deprecated(since = "0.3.0", note = "use PrimOp::into_value")]
     pub fn new_value_primop(&mut self, primop: primop::PrimOp) -> Result<Value> {
-        let value = self.new_value_uninitialized()?;
-        unsafe {
-            check_call!(raw::init_primop(
-                &mut self.context,
-                value.raw_ptr(),
-                primop.ptr
-            ))?;
-        };
-        Ok(value)
+        primop.into_value(self)
     }
 
     /// Creates a new [attribute set][`ValueType::AttrSet`] Nix value from an iterator of name-value pairs.
@@ -2191,7 +2175,6 @@ mod tests {
             let bias_control = bias.clone();
 
             let primop = primop::PrimOp::new(
-                &mut es,
                 primop::PrimOpMeta {
                     name: cstr!("testFunction"),
                     args: [cstr!("a"), cstr!("b")],
@@ -2206,7 +2189,7 @@ mod tests {
             )
             .unwrap();
 
-            let f = es.new_value_primop(primop).unwrap();
+            let f = primop.into_value(&mut es).unwrap();
 
             {
                 *bias_control.lock().unwrap() = 10;
@@ -2230,9 +2213,7 @@ mod tests {
             let store = Store::open(None, []).unwrap();
             let mut es = EvalState::new(store, []).unwrap();
             let f = {
-                let es: &mut EvalState = &mut es;
                 let prim = primop::PrimOp::new(
-                    es,
                     primop::PrimOpMeta {
                         name: cstr!("throwingTestFunction"),
                         args: [cstr!("arg")],
@@ -2245,7 +2226,7 @@ mod tests {
                 )
                 .unwrap();
 
-                es.new_value_primop(prim)
+                prim.into_value(&mut es)
             }
             .unwrap();
             let a = es.new_value_int(2).unwrap();
@@ -2323,7 +2304,6 @@ mod tests {
             let store = Store::open(None, []).unwrap();
             let mut es = EvalState::new(store, []).unwrap();
             let primop = primop::PrimOp::new(
-                &mut es,
                 primop::PrimOpMeta {
                     name: cstr!("frobnicate"),
                     doc: cstr!("Frobnicates widgets"),
@@ -2336,7 +2316,7 @@ mod tests {
                 }),
             )
             .unwrap();
-            let f = es.new_value_primop(primop).unwrap();
+            let f = primop.into_value(&mut es).unwrap();
             let a = es.new_value_int(2).unwrap();
             let b = es.new_value_int(3).unwrap();
             let fa = es.call(f, a).unwrap();
@@ -2356,7 +2336,6 @@ mod tests {
             let store = Store::open(None, []).unwrap();
             let mut es = EvalState::new(store, []).unwrap();
             let primop = primop::PrimOp::new(
-                &mut es,
                 primop::PrimOpMeta {
                     name: cstr!("frobnicate"),
                     doc: cstr!("Frobnicates widgets"),
@@ -2365,7 +2344,7 @@ mod tests {
                 Box::new(|_es, _args| bail!("The frob unexpectedly fizzled")),
             )
             .unwrap();
-            let f = es.new_value_primop(primop).unwrap();
+            let f = primop.into_value(&mut es).unwrap();
             let a = es.new_value_int(0).unwrap();
             match es.call(f, a) {
                 Ok(_) => panic!("expected an error"),
@@ -2873,6 +2852,38 @@ mod tests {
             es.force(&v).unwrap();
             let i = es.require_int(&v).unwrap();
             assert_eq!(i, 42);
+        })
+        .unwrap();
+    }
+
+    // Note: `nix_register_primop` has process-global effect that persists for
+    // the remaining test executions.
+    #[test]
+    fn eval_state_primop_register_builtin() {
+        gc_registering_current_thread(|| {
+            let primop = primop::PrimOp::new(
+                primop::PrimOpMeta {
+                    name: cstr!("__test_answer"),
+                    doc: cstr!("Returns the answer to life, the universe, and everything."),
+                    args: [cstr!("_ignored")],
+                },
+                Box::new(|es, _args| es.new_value_int(42)),
+            )
+            .unwrap();
+            primop.register_globally().unwrap();
+
+            // Fresh EvalState created *after* register — this is what
+            // registered builtins must be usable from.
+            let store = Store::open(None, HashMap::new()).unwrap();
+            let mut es = EvalState::new(store, []).unwrap();
+            // Top-level: the `__`-prefixed name is exposed in the base env.
+            let v = es.eval_from_string("__test_answer null", "<test>").unwrap();
+            assert_eq!(es.require_int(&v).unwrap(), 42);
+            // `builtins.*`: Nix strips the leading `__` when populating it.
+            let v = es
+                .eval_from_string("builtins.test_answer null", "<test>")
+                .unwrap();
+            assert_eq!(es.require_int(&v).unwrap(), 42);
         })
         .unwrap();
     }

--- a/nix-bindings-expr/src/eval_state.rs
+++ b/nix-bindings-expr/src/eval_state.rs
@@ -147,7 +147,7 @@ use std::ffi::{c_char, CString};
 use std::iter::FromIterator;
 use std::os::raw::c_uint;
 use std::ptr::{null, null_mut, NonNull};
-use std::sync::{Arc, LazyLock, Weak};
+use std::sync::LazyLock;
 
 static INIT: LazyLock<Result<()>> = LazyLock::new(|| unsafe {
     gc::GC_allow_register_threads();
@@ -174,22 +174,6 @@ pub struct RealisedString {
     pub s: String,
     /// Store paths referenced by the string.
     pub paths: Vec<StorePath>,
-}
-
-/// A [Weak] reference to an [EvalState].
-pub struct EvalStateWeak {
-    inner: Weak<EvalStateRef>,
-}
-impl EvalStateWeak {
-    /// Upgrade the weak reference to a proper [EvalState].
-    ///
-    /// If no normal reference to the [EvalState] is around anymore elsewhere, this fails by returning `None`.
-    pub fn upgrade(&self) -> Option<EvalState> {
-        self.inner.upgrade().map(|eval_state| EvalState {
-            eval_state,
-            context: Context::new(),
-        })
-    }
 }
 
 pub(crate) struct EvalStateRef {
@@ -331,12 +315,12 @@ impl EvalStateBuilder {
         let eval_state =
             unsafe { check_call!(raw::eval_state_build(&mut context, self.eval_state_builder)) }?;
         Ok(EvalState {
-            eval_state: Arc::new(EvalStateRef {
+            eval_state: EvalStateRef {
                 eval_state: NonNull::new(eval_state).unwrap_or_else(|| {
                     panic!("nix_state_create returned a null pointer without an error")
                 }),
                 owned: true,
-            }),
+            },
             context,
         })
     }
@@ -352,7 +336,7 @@ impl EvalStateBuilder {
 }
 
 pub struct EvalState {
-    eval_state: Arc<EvalStateRef>,
+    pub(crate) eval_state: EvalStateRef,
     pub(crate) context: Context,
 }
 impl EvalState {
@@ -374,13 +358,6 @@ impl EvalState {
         self.eval_state.as_ptr()
     }
 
-    /// Creates a weak reference to this EvalState.
-    pub fn weak_ref(&self) -> EvalStateWeak {
-        EvalStateWeak {
-            inner: Arc::downgrade(&self.eval_state),
-        }
-    }
-
     /// Wraps a raw `EvalState *` borrowed from the Nix C API.
     ///
     /// # Safety
@@ -388,10 +365,10 @@ impl EvalState {
     /// The returned `EvalState` must not outlive the underlying pointer.
     pub(crate) unsafe fn from_raw_borrowed(ptr: NonNull<raw::EvalState>) -> Self {
         EvalState {
-            eval_state: Arc::new(EvalStateRef {
+            eval_state: EvalStateRef {
                 eval_state: ptr,
                 owned: false,
-            }),
+            },
             context: Context::new(),
         }
     }
@@ -1228,15 +1205,6 @@ pub fn gc_register_my_thread() -> Result<ThreadRegistrationGuard> {
     }
 }
 
-impl Clone for EvalState {
-    fn clone(&self) -> Self {
-        EvalState {
-            eval_state: self.eval_state.clone(),
-            context: Context::new(),
-        }
-    }
-}
-
 /// Initialize the Nix library for testing. This includes some modifications to the Nix settings, that must not be used in production.
 /// Use at your own peril, in rust test suites.
 #[doc(alias = "test_initialize")]
@@ -1305,31 +1273,11 @@ mod tests {
         .unwrap();
     }
 
-    #[test]
-    fn weak_ref() {
-        gc_registering_current_thread(|| {
-            let store = Store::open(None, HashMap::new()).unwrap();
-            let es = EvalState::new(store, []).unwrap();
-            let weak = es.weak_ref();
-            let _es = weak.upgrade().unwrap();
-        })
-        .unwrap();
-    }
-
-    #[test]
-    fn weak_ref_gone() {
-        gc_registering_current_thread(|| {
-            let weak = {
-                // Use a slightly different URL which is unique in the test suite, to bypass the global store cache
-                let store = Store::open(Some("auto?foo=bar"), HashMap::new()).unwrap();
-                let es = EvalState::new(store, []).unwrap();
-                es.weak_ref()
-            };
-            assert!(weak.upgrade().is_none());
-            assert!(weak.inner.upgrade().is_none());
-        })
-        .unwrap();
-    }
+    // Nix is not thread safe yet.
+    // When it is, and the C API documentation supports that claim, these could
+    // be implemented.
+    // Until then, if you want to take the risk, you'll have to use `unsafe`.
+    static_assertions::assert_not_impl_any!(EvalState: Send, Sync);
 
     #[test]
     fn eval_state_lookup_path() {

--- a/nix-bindings-expr/src/primop.rs
+++ b/nix-bindings-expr/src/primop.rs
@@ -3,6 +3,7 @@ use crate::value::Value;
 use anyhow::Result;
 use nix_bindings_expr_sys as raw;
 use nix_bindings_util::check_call;
+use nix_bindings_util::context::Context;
 use nix_bindings_util_sys as raw_util;
 use std::ffi::{c_int, c_void, CStr, CString};
 use std::mem::ManuallyDrop;
@@ -55,7 +56,7 @@ pub struct PrimOpMeta<'a, const N: usize> {
 }
 
 pub struct PrimOp {
-    pub(crate) ptr: *mut raw::PrimOp,
+    ptr: *mut raw::PrimOp,
 }
 impl Drop for PrimOp {
     fn drop(&mut self) {
@@ -67,11 +68,13 @@ impl Drop for PrimOp {
 impl PrimOp {
     /// Create a new primop with the given metadata and implementation.
     ///
+    /// The primop is not tied to an [`EvalState`]; the callback argument comes
+    /// directly from Nix.
+    ///
     /// When `f` returns an `Err`, the error is propagated to the Nix evaluator.
     /// To return a [recoverable error](RecoverableError), include it in the
     /// error chain (e.g. `Err(RecoverableError::new("...").into())`).
     pub fn new<const N: usize>(
-        eval_state: &mut EvalState,
         meta: PrimOpMeta<N>,
         f: Box<dyn Fn(&mut EvalState, &[Value; N]) -> Result<Value>>,
     ) -> Result<PrimOp> {
@@ -94,9 +97,10 @@ impl PrimOp {
             }));
             user_data.as_ref() as *const PrimOpContext as *mut c_void
         };
+        let mut ctx = Context::new();
         let op = unsafe {
             check_call!(raw::alloc_primop(
-                &mut eval_state.context,
+                &mut ctx,
                 FUNCTION_ADAPTER,
                 N as c_int,
                 meta.name.as_ptr(),
@@ -106,6 +110,44 @@ impl PrimOp {
             ))?
         };
         Ok(PrimOp { ptr: op })
+    }
+
+    /// Creates a [function][`crate::value::ValueType::Function`] [`Value`]
+    /// backed by this primop, in the given [`EvalState`].
+    ///
+    /// Consumes the [`PrimOp`] as ownership moves to the Nix GC. The returned
+    /// [`Value`] or other references in the Nix heap keep it alive.
+    ///
+    /// This fully consumes the `PrimOp` because the C API leaves it invalid.
+    #[doc(alias = "make_primop")]
+    #[doc(alias = "create_function")]
+    #[doc(alias = "builtin")]
+    #[doc(alias = "init_primop")]
+    pub fn into_value(self, eval_state: &mut EvalState) -> Result<Value> {
+        let value = eval_state.new_value_uninitialized()?;
+        unsafe {
+            check_call!(raw::init_primop(
+                &mut eval_state.context,
+                value.raw_ptr(),
+                self.ptr
+            ))?;
+        }
+        Ok(value)
+    }
+
+    /// Registers this primop into future `EvalState`s.
+    ///
+    /// Per the Nix C API (`nix_register_primop`), this only affects
+    /// [`EvalState`]s created *after* the call.
+    ///
+    /// This fully consumes the `PrimOp` because the C API leaves it invalid.
+    #[doc(alias = "nix_register_primop")]
+    pub fn register_globally(self) -> Result<()> {
+        let mut ctx = Context::new();
+        unsafe {
+            check_call!(raw::register_primop(&mut ctx, self.ptr))?;
+        }
+        Ok(())
     }
 }
 

--- a/nix-bindings-expr/src/primop.rs
+++ b/nix-bindings-expr/src/primop.rs
@@ -1,4 +1,4 @@
-use crate::eval_state::{EvalState, EvalStateWeak};
+use crate::eval_state::EvalState;
 use crate::value::Value;
 use anyhow::Result;
 use nix_bindings_expr_sys as raw;
@@ -6,7 +6,7 @@ use nix_bindings_util::check_call;
 use nix_bindings_util_sys as raw_util;
 use std::ffi::{c_int, c_void, CStr, CString};
 use std::mem::ManuallyDrop;
-use std::ptr::{null, null_mut};
+use std::ptr::{null, null_mut, NonNull};
 
 /// A primop error that is not memoized in the thunk that triggered it,
 /// allowing the thunk to be forced again.
@@ -91,7 +91,6 @@ impl PrimOp {
             let user_data = ManuallyDrop::new(Box::new(PrimOpContext {
                 arity: N,
                 function: Box::new(move |eval_state, args| f(eval_state, args.try_into().unwrap())),
-                eval_state: eval_state.weak_ref(),
             }));
             user_data.as_ref() as *const PrimOpContext as *mut c_void
         };
@@ -114,20 +113,19 @@ impl PrimOp {
 struct PrimOpContext {
     arity: usize,
     function: Box<dyn Fn(&mut EvalState, &[Value]) -> Result<Value>>,
-    eval_state: EvalStateWeak,
 }
 
 unsafe extern "C" fn function_adapter(
     user_data: *mut ::std::os::raw::c_void,
     context_out: *mut raw_util::c_context,
-    _state: *mut raw::EvalState,
+    state: *mut raw::EvalState,
     args: *mut *mut raw::Value,
     ret: *mut raw::Value,
 ) {
     let primop_info = (user_data as *const PrimOpContext).as_ref().unwrap();
-    let mut eval_state = primop_info.eval_state.upgrade().unwrap_or_else(|| {
-        panic!("Nix primop called after EvalState was dropped");
-    });
+    let mut eval_state = EvalState::from_raw_borrowed(
+        NonNull::new(state).expect("Nix primop callback given null EvalState pointer"),
+    );
     let args_raw_slice = unsafe { std::slice::from_raw_parts(args, primop_info.arity) };
     let args_vec: Vec<Value> = args_raw_slice
         .iter()
@@ -150,6 +148,8 @@ unsafe extern "C" fn function_adapter(
             raw_util::set_err_msg(context_out, err_code, cstr.as_ptr());
         },
     }
+    // Safety(EvalState::from_raw_borrowed): do not outlive owner, this call
+    drop(eval_state);
 }
 
 fn error_code(e: &anyhow::Error) -> raw_util::err {


### PR DESCRIPTION
Support for `builtins` registration through `PrimOp::register()` and a few (mildly?) breaking changes largely but not exclusively in support of that feature.
Main breakage:
- No `EvalState` on `PrimOp` construction
- No more internal `Arc` or `store` in `EvalState`
