### PR TITLE
nix-binding-expr: Add C API function nix_eval_state_builder_set_setting

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -98,11 +98,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -116,20 +116,17 @@
         "flake-compat": [
           "nix"
         ],
-        "gitignore": [
-          "nix"
-        ],
         "nixpkgs": [
           "nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781733627,
-        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
@@ -166,11 +163,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1783030128,
-        "narHash": "sha256-WfRmwMYdnzwhMrbAy8dGIshMUd/u2UzyiyZrhLKDZig=",
+        "lastModified": 1784913946,
+        "narHash": "sha256-ThcOJQuo78GbVl9bdj/1X40fTCYSU5PcZkqktA8rVh8=",
         "owner": "NixOS",
         "repo": "nix",
-        "rev": "b41781ed09cc718773b19c04b322601e2c00db1a",
+        "rev": "731e197c4f1ae09815bcd968571f09057c450609",
         "type": "github"
       },
       "original": {

--- a/nix-bindings-expr/build.rs
+++ b/nix-bindings-expr/build.rs
@@ -2,5 +2,5 @@ use nix_bindings_util::nix_version::emit_version_cfg;
 
 fn main() {
     let nix_version = pkg_config::probe_library("nix-expr-c").unwrap().version;
-    emit_version_cfg(&nix_version, &["2.26", "2.34.0pre"]);
+    emit_version_cfg(&nix_version, &["2.26", "2.34.0pre", "2.36.0pre"]);
 }

--- a/nix-bindings-expr/src/eval_state.rs
+++ b/nix-bindings-expr/src/eval_state.rs
@@ -294,6 +294,29 @@ impl EvalStateBuilder {
         self.load_ambient_settings = load;
         self
     }
+
+    /// Sets a single evaluator setting (as documented in the Nix manual) on the builder.
+    ///
+    /// Requires Nix >= 2.36.0pre (`nix_eval_state_builder_set_setting`).
+    #[cfg(nix_at_least = "2.36.0pre")]
+    pub fn set_setting(self, key: &str, value: &str) -> Result<Self> {
+        let key_c = CString::new(key).with_context(|| {
+            format!("EvalStateBuilder::set_setting: key `{key}` contains null byte")
+        })?;
+        let value_c = CString::new(value).with_context(|| {
+            format!("EvalStateBuilder::set_setting: value `{value}` contains null byte")
+        })?;
+        let mut context = Context::new();
+        unsafe {
+            check_call!(raw::eval_state_builder_set_setting(
+                &mut context,
+                self.eval_state_builder,
+                key_c.as_ptr(),
+                value_c.as_ptr()
+            ))?;
+        }
+        Ok(self)
+    }
     /// Builds the configured [`EvalState`].
     pub fn build(&self) -> Result<EvalState> {
         // Make sure the library is initialized
@@ -1393,6 +1416,44 @@ mod tests {
     }
 
     #[test]
+    #[cfg(nix_at_least = "2.36.0pre" /* eval_state_builder_set_setting */)]
+    fn eval_state_builder_set_setting() {
+        // Test whether setting eval settings via the C-api actually apply.
+        gc_registering_current_thread(|| {
+            // Presence of builtins.currentSystem is used as an indicater whether pure-eval is used or not.
+            fn has_current_system(es: &mut EvalState) -> bool {
+                let v = es
+                    .eval_from_string("builtins ? currentSystem", "<test>")
+                    .unwrap();
+                es.force(&v).unwrap();
+                es.require_bool(&v).unwrap()
+            }
+
+            // A builder with no settings evaluates impurely.
+            let mut impure = EvalStateBuilder::new(Store::open(None, HashMap::new()).unwrap())
+                .unwrap()
+                .build()
+                .unwrap();
+            assert!(has_current_system(&mut impure));
+
+            // A builder with pure-eval applied has no builtins.currentSystem
+            let builder = EvalStateBuilder::new(Store::open(None, HashMap::new()).unwrap())
+                .unwrap()
+                .set_setting("pure-eval", "true")
+                .unwrap();
+            let mut pure = builder.build().unwrap();
+            assert!(!has_current_system(&mut pure));
+
+            // An unknown setting errors out.
+            let unknown = EvalStateBuilder::new(Store::open(None, HashMap::new()).unwrap())
+                .unwrap()
+                .set_setting("not-a-nix-setting", "x");
+            assert!(unknown.is_err());
+        })
+        .unwrap();
+    }
+
+    #[test]
     fn eval_state_value_int() {
         gc_registering_current_thread(|| {
             let store = Store::open(None, HashMap::new()).unwrap();
@@ -1929,7 +1990,7 @@ mod tests {
                             }}
                     a path: ${builtins.toFile "just-a-file" "ooh file good"}
                     a derivation path by itself: ${
-                        builtins.unsafeDiscardOutputDependency 
+                        builtins.unsafeDiscardOutputDependency
                             (derivation {
                                 name = "not-actually-built-yet";
                                 system = builtins.currentSystem;


### PR DESCRIPTION
To be able to drive evaluator settings from the C API. My motivation is to be able to set `pure-eval` without having global config state.

Depends on https://github.com/NixOS/nix/pull/16199.