### PR TITLE
Add Nix logger activity bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,7 +63,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.114",
  "which",
 ]
 
@@ -131,6 +137,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,7 +205,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.199"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824894a4a85dca76d4c95c2b9098c036f5a29f627b30c12780774f6654e60974"
+dependencies = [
+ "cc",
+ "cxx-build",
+ "cxxbridge-cmd",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "foldhash",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.199"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1ae0b651ea5b0000b19513aef5a03f194d7e3486f2d9258b658da8677fe9036"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "indexmap 2.13.0",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "cxxbridge-cmd"
+version = "1.0.199"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb05f91d3fb8435d9bab6ac5ce6ac1868be774325fb7fb2a91be39393b21388e"
+dependencies = [
+ "clap",
+ "codespan-reporting",
+ "indexmap 2.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.199"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf293202e0e3e98495785745389e8d0755b217e66f19194a5c695c25e03282ef"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.199"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca001d746947c7249ed9d332a10f7a59daedbafeb0ec68c5c18a7db7a93f6ccc"
+dependencies = [
+ "indexmap 2.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -186,7 +291,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -197,7 +302,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -235,7 +340,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.114",
  "unicode-xid",
 ]
 
@@ -284,6 +389,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "getrandom"
@@ -503,6 +614,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-cplusplus"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +755,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix-bindings-logger"
+version = "0.2.2"
+dependencies = [
+ "cxx",
+ "cxx-build",
+ "pkg-config",
+]
+
+[[package]]
 name = "nix-bindings-store"
 version = "0.2.2"
 dependencies = [
@@ -722,7 +851,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -756,7 +885,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -809,7 +938,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -927,6 +1056,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scratch"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,7 +1094,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1003,7 +1138,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1050,6 +1185,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1206,15 @@ dependencies = [
  "once_cell",
  "rustix 1.1.3",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1079,7 +1234,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1137,7 +1292,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1189,7 +1344,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1212,6 +1367,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -1272,7 +1433,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -1298,6 +1459,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,7 +1488,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1329,7 +1499,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1553,7 +1723,7 @@ checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "nix-bindings-expr",
     "nix-bindings-fetchers",
     "nix-bindings-flake",
+    "nix-bindings-logger",
     "nix-bindings-store",
     "nix-bindings-util",
 ]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This workspace provides multiple crates that wrap different layers of the Nix C 
 - **`nix-bindings-expr`** - Expression evaluation and type extraction
 - **`nix-bindings-flake`** - Flake operations
 - **`nix-bindings-fetchers`** - Fetcher functionality (requires Nix ≥ 2.29)
+- **`nix-bindings-logger`** - Log messages and build activities through Nix's
+  in-process logger using a small CXX bridge
 
 The `*-sys` crates contain generated FFI bindings and are not intended for direct use.
 

--- a/dev/flake-module.nix
+++ b/dev/flake-module.nix
@@ -78,6 +78,7 @@
             "nix-bindings-fetchers"
             "nix-bindings-flake-sys"
             "nix-bindings-flake"
+            "nix-bindings-logger"
           ];
           packageFlags = pkgs.lib.concatMapStringsSep " " (c: "-p ${c}") crates;
         in
@@ -142,6 +143,7 @@
                       <li><span class="crate"><a href="nix_bindings_expr/index.html">nix_bindings_expr</a></span><span class="desc">— Expression evaluation</span></li>
                       <li><span class="crate"><a href="nix_bindings_fetchers/index.html">nix_bindings_fetchers</a></span><span class="desc">— Fetcher operations</span></li>
                       <li><span class="crate"><a href="nix_bindings_flake/index.html">nix_bindings_flake</a></span><span class="desc">— Flake operations</span></li>
+                      <li><span class="crate"><a href="nix_bindings_logger/index.html">nix_bindings_logger</a></span><span class="desc">— In-process logging and build activities</span></li>
                       <li><span class="crate"><a href="nix_bindings_util/index.html">nix_bindings_util</a></span><span class="desc">— Utilities</span></li>
                     </ul>
                     <details>

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Rust bindings for the Nix C API";
+  description = "Rust bindings for Nix's C API and focused C++ extension points";
 
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";

--- a/input-propagation-workaround.nix
+++ b/input-propagation-workaround.nix
@@ -26,6 +26,7 @@
         else
           # Fallback for older Nix versions without split libs
           {
+            nix-util = nixPackage;
             nix-util-c = nixPackage;
             nix-store-c = nixPackage;
             nix-expr-c = nixPackage;
@@ -109,6 +110,7 @@
         nix-bindings-rust.inputPropagationWorkaround.crateInputMapping = {
           # -sys crates with their transitive dependencies
           "nix-bindings-bdwgc-sys" = [ pkgs.boehmgc ];
+          "nix-bindings-logger" = [ nixLibs.nix-util.dev ];
           "nix-bindings-util-sys" = [ nixLibs.nix-util-c.dev ];
           "nix-bindings-store-sys" = [
             nixLibs.nix-store-c.dev

--- a/nix-bindings-logger/Cargo.toml
+++ b/nix-bindings-logger/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "nix-bindings-logger"
+description = "Rust bindings for emitting messages and activities through Nix's in-process logger"
+version = "0.2.2"
+edition = "2021"
+build = "build.rs"
+license = "LGPL-2.1"
+repository = "https://github.com/nixops4/nix-bindings-rust"
+documentation = "https://nixops4.github.io/nix-bindings-rust/development/nix_bindings_logger/"
+readme = "README.md"
+
+[dependencies]
+cxx = "1.0"
+
+[build-dependencies]
+cxx-build = "1.0"
+pkg-config = "0.3"
+
+[lints]
+workspace = true

--- a/nix-bindings-logger/README.md
+++ b/nix-bindings-logger/README.md
@@ -1,0 +1,9 @@
+# nix-bindings-logger
+
+Emit log messages and build activities through the logger of the hosting Nix
+process.
+
+Nix's C API does not expose logger emission. This crate provides that capability
+through a small CXX bridge to Nix's process-global logger and `nix::Activity`.
+It is intended for code loaded into a running Nix process, such as a store
+plugin.

--- a/nix-bindings-logger/build.rs
+++ b/nix-bindings-logger/build.rs
@@ -1,0 +1,30 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    println!("cargo:rerun-if-changed=src/bridge.rs");
+    println!("cargo:rerun-if-changed=src/shim.cc");
+    println!("cargo:rerun-if-changed=include/nix-bindings-logger/shim.hh");
+
+    let nix_util = pkg_config::Config::new()
+        .probe("nix-util")
+        .expect("nix-util not found via pkg-config");
+
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let mut build = cxx_build::bridge("src/bridge.rs");
+    for path in &nix_util.include_paths {
+        build.include(path);
+    }
+    build.include(manifest_dir.join("include"));
+    build.file("src/shim.cc");
+    build.std("c++23");
+    build.flag_if_supported("-Wno-unused-parameter");
+    build.compile("nix-bindings-logger-cxx");
+
+    for lib in &nix_util.libs {
+        println!("cargo:rustc-link-lib={lib}");
+    }
+    for path in &nix_util.link_paths {
+        println!("cargo:rustc-link-search=native={}", path.display());
+    }
+}

--- a/nix-bindings-logger/include/nix-bindings-logger/shim.hh
+++ b/nix-bindings-logger/include/nix-bindings-logger/shim.hh
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include "nix/util/logging.hh"
+#include "rust/cxx.h"
+
+namespace nix::rust_bindings {
+
+enum class LogLevel : std::uint8_t;
+
+// Opaque to Rust. Keeping Activity by value inside the heap allocation avoids
+// moving Nix's non-movable activity after construction.
+struct BuildActivity
+{
+    ::nix::Activity activity;
+
+    explicit BuildActivity(const std::string & description)
+        : activity(*::nix::logger, ::nix::lvlInfo, ::nix::actBuild, description)
+    {
+    }
+};
+
+std::unique_ptr<BuildActivity> start_build_activity(rust::Str description) noexcept;
+void build_log_line(const BuildActivity & activity, rust::Str line) noexcept;
+void log_message(LogLevel level, rust::Str message) noexcept;
+
+} // namespace nix::rust_bindings

--- a/nix-bindings-logger/src/bridge.rs
+++ b/nix-bindings-logger/src/bridge.rs
@@ -1,0 +1,24 @@
+#[cxx::bridge(namespace = "nix::rust_bindings")]
+pub(crate) mod ffi {
+    /// Nix logger verbosity.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum LogLevel {
+        Error = 0,
+        Warn = 1,
+        Notice = 2,
+        Info = 3,
+        Talkative = 4,
+        Chatty = 5,
+        Debug = 6,
+        Vomit = 7,
+    }
+
+    unsafe extern "C++" {
+        include!("nix-bindings-logger/shim.hh");
+
+        type BuildActivity;
+        fn start_build_activity(description: &str) -> UniquePtr<BuildActivity>;
+        fn build_log_line(activity: &BuildActivity, line: &str);
+        fn log_message(level: LogLevel, message: &str);
+    }
+}

--- a/nix-bindings-logger/src/lib.rs
+++ b/nix-bindings-logger/src/lib.rs
@@ -1,0 +1,82 @@
+//! Emit messages and build activities through the logger of the hosting Nix
+//! process.
+//!
+//! Nix's C API does not expose logger emission. This crate provides that
+//! capability through a small CXX bridge to Nix's process-global logger and
+//! `nix::Activity`. It is intended for code loaded into a running Nix process,
+//! such as a store plugin.
+
+mod bridge;
+
+use cxx::UniquePtr;
+
+use crate::bridge::ffi;
+
+pub use crate::bridge::ffi::LogLevel;
+
+/// Emit a message through Nix's process-global logger.
+///
+/// The hosting process decides whether the message is visible based on its
+/// configured verbosity and log format. Logging is a no-op if the process has
+/// no active logger.
+pub fn log(level: LogLevel, message: &str) {
+    ffi::log_message(level, message);
+}
+
+/// A live Nix build activity.
+///
+/// Lines emitted through this handle appear in `nix build -L`. Dropping the
+/// handle ends the activity.
+#[must_use = "dropping the handle immediately ends the Nix build activity"]
+pub struct BuildLog(UniquePtr<ffi::BuildActivity>);
+
+// SAFETY: the handle only submits results to Nix's process-global logger,
+// which synchronizes activity updates internally. The C++ activity object is
+// never moved after construction.
+unsafe impl Send for BuildLog {}
+unsafe impl Sync for BuildLog {}
+
+impl BuildLog {
+    /// Start a build activity with a human-readable description.
+    pub fn start(description: &str) -> Self {
+        Self(ffi::start_build_activity(description))
+    }
+
+    /// Whether the hosting process had a logger with which to create the
+    /// activity.
+    pub fn is_active(&self) -> bool {
+        !self.0.is_null()
+    }
+
+    /// Emit one line of build output. Non-UTF-8 bytes are rendered lossily.
+    ///
+    /// This is a no-op if Nix could not create the activity.
+    pub fn line(&self, line: &[u8]) {
+        if let Some(activity) = self.0.as_ref() {
+            ffi::build_log_line(activity, &String::from_utf8_lossy(line));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emits_message() {
+        log(LogLevel::Info, "nix-bindings-logger message smoke test");
+    }
+
+    #[test]
+    fn emits_build_log_line() {
+        let log = BuildLog::start("nix-bindings-logger activity smoke test");
+        assert!(log.is_active());
+        log.line(b"build log line");
+    }
+
+    #[test]
+    fn accepts_non_utf8_build_output() {
+        let log = BuildLog::start("nix-bindings-logger non-UTF-8 smoke test");
+        log.line(b"invalid byte: \xff");
+    }
+}

--- a/nix-bindings-logger/src/shim.cc
+++ b/nix-bindings-logger/src/shim.cc
@@ -1,0 +1,64 @@
+#include "nix-bindings-logger/shim.hh"
+
+#include "nix-bindings-logger/src/bridge.rs.h"
+
+namespace nix::rust_bindings {
+
+static ::nix::Verbosity to_verbosity(LogLevel level) noexcept
+{
+    switch (level) {
+    case LogLevel::Error:
+        return ::nix::lvlError;
+    case LogLevel::Warn:
+        return ::nix::lvlWarn;
+    case LogLevel::Notice:
+        return ::nix::lvlNotice;
+    case LogLevel::Info:
+        return ::nix::lvlInfo;
+    case LogLevel::Talkative:
+        return ::nix::lvlTalkative;
+    case LogLevel::Chatty:
+        return ::nix::lvlChatty;
+    case LogLevel::Debug:
+        return ::nix::lvlDebug;
+    case LogLevel::Vomit:
+        return ::nix::lvlVomit;
+    }
+
+    return ::nix::lvlInfo;
+}
+
+std::unique_ptr<BuildActivity> start_build_activity(rust::Str description) noexcept
+{
+    try {
+        if (!::nix::logger)
+            return nullptr;
+        return std::make_unique<BuildActivity>(std::string(description.data(), description.size()));
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+void build_log_line(const BuildActivity & activity, rust::Str line) noexcept
+{
+    try {
+        activity.activity.result(
+            ::nix::resBuildLogLine,
+            std::string(line.data(), line.size()));
+    } catch (...) {
+    }
+}
+
+void log_message(LogLevel level, rust::Str message) noexcept
+{
+    try {
+        if (!::nix::logger)
+            return;
+        ::nix::logger->log(
+            to_verbosity(level),
+            std::string_view(message.data(), message.size()));
+    } catch (...) {
+    }
+}
+
+} // namespace nix::rust_bindings


### PR DESCRIPTION
## Summary

- add a CXX-backed `nix-bindings-logger` crate
- expose process-global log messages and scoped build activities/build-log lines
- integrate the crate with native-input propagation and generated workspace docs

## Why

Nix's C API does not expose logger emission. Code loaded into a Nix process—such as a store plugin—needs to create `nix::Activity` instances so build output appears in `nix build -L` without carrying an application-specific C++ shim.

## Impact

Downstream plugins can reuse a small, process-safe Rust API for Nix logging while keeping application-specific plugin bindings separate.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p nix-bindings-logger` with Nix 2.34
- parsed the changed Nix modules with `nix-instantiate --parse`


cc @roberth 